### PR TITLE
Upgrade NPM Publish Node Version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-sumerian-hosts",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-sumerian-hosts",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-sumerian-hosts",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "scripts": {
     "test": "OS_NAME=\"$(uname)\" node ./node_modules/karma/bin/karma start",


### PR DESCRIPTION
### What
Upgrade Node JS's publish version from 12.x to 16.x. 

### Why
Worker [failed to publish](https://github.com/aws-samples/amazon-sumerian-hosts/actions/runs/1849333287) with latest v1.3.6. As recommended from [this post](https://stackoverflow.com/a/66853873), it seems upgrading Node JS can alleviate the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
