### PR TITLE
update npm publish workspaces

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - run: npm publish
+      - run: npm publish --workspaces
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What:
The Host repo has a GitHub Action to automatically publish package to npm registry after a release version created.
After splitting the packages, we have to update the npm publish command line to work well with the monorepo structure.

### Why:
Using workflow can easily maintain the package publishing and save developers time.

### Test:
npm publish --workspaces --dry-run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
