### PR TITLE
Fix Dev Server Not Starting

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/webpack.dev.js
+++ b/packages/amazon-sumerian-hosts-babylon/webpack.dev.js
@@ -4,7 +4,7 @@ const {merge} = require('webpack-merge');
 const path = require('path');
 const common = require('./webpack.common.js');
 
-module.exports = merge(common[0], {
+module.exports = merge(common, {
   mode: 'development',
   devtool: 'eval-source-map',
   resolve: {

--- a/packages/amazon-sumerian-hosts-core/webpack.dev.js
+++ b/packages/amazon-sumerian-hosts-core/webpack.dev.js
@@ -4,7 +4,7 @@ const {merge} = require('webpack-merge');
 const path = require('path');
 const common = require('./webpack.common.js');
 
-module.exports = merge(common[0], {
+module.exports = merge(common, {
   mode: 'development',
   devtool: 'eval-source-map',
   devServer: {

--- a/packages/amazon-sumerian-hosts-three/webpack.dev.js
+++ b/packages/amazon-sumerian-hosts-three/webpack.dev.js
@@ -4,7 +4,7 @@ const {merge} = require('webpack-merge');
 const path = require('path');
 const common = require('./webpack.common.js');
 
-module.exports = merge(common[0], {
+module.exports = merge(common, {
   mode: 'development',
   devtool: 'eval-source-map',
   resolve: {


### PR DESCRIPTION
### What:
With the recent changes to drop an array of exports for the webpack, we accidentally did not remove the array reference from the dev server startup. 

### Why:
This command needs to be working causes developers to not be able to run their local server. 

### Test:
`npm run --workspace=./packages/amazon-sumerian-hosts-three start`
`npm run --workspace=./packages/amazon-sumerian-hosts-babylon start`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
