### PR TITLE
Add CodeQL to Action workflows.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: Run build/tests/lint on pull requests
 
 on:
   pull_request:
+  push:
 
 # By default the karma test runners use the karma 'Chrome' runner
 # This is great when running locally because the browser pops up and you get to see what it does
@@ -14,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -21,3 +24,6 @@ jobs:
       - run: npm install
       - run: chromium --version
       - run: npm run build-test
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+


### PR DESCRIPTION
This change adds the default CodeQL analysis to our PR workflow.

It also turns on our default workflow to run on pushes. As a side-effect, this will ensure the build is ran if someone pushes directly to the repo with a PR, but the primary purpose is to configure CodeQL to run against the branch itself, and not just a PR. This is necessary for CodeQL to detect risk changes.

This PR will fail the CodeQL check due to some regex problems in the compiled docs output.

I have tested in my forked repo, and if we merge this anyway, then these alerts stick around in the `Security` tab in github, but subsequent PRs will not fail as CodeQL will recognize that we previously accepted these risks.

We need to figure out what to do with the doc site and fix it up, but I wanted to get this in so we get immediate feedback as we continue to write core code in this repo

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
