### PR TITLE
Fix: loadAssetContainerAsync should pass in scene

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -153,7 +153,7 @@ class HostObject extends CoreHostObject {
     },
   ) {
     // Load character model
-    const characterAsset = await BABYLON.SceneLoader.LoadAssetContainerAsync(modelUrl);
+    const characterAsset = await BABYLON.SceneLoader.LoadAssetContainerAsync(modelUrl, undefined, scene);
     const characterMesh = characterAsset.meshes[0];
 
     // rename mesh to something human-readable instead of the default '__root__'
@@ -220,7 +220,7 @@ class HostObject extends CoreHostObject {
  ````
    */
   static async loadAnimation(scene, childMeshes, url, clipGroupId) {
-    const container = await BABYLON.SceneLoader.LoadAssetContainerAsync(url)
+    const container = await BABYLON.SceneLoader.LoadAssetContainerAsync(url, undefined, scene);
 
     const startingIndex = scene.animatables.length;
     const firstIndex = scene.animationGroups.length;


### PR DESCRIPTION
*Issue #, if available:* 11141

*Description of changes:*
This change is to fix a bug seen in the BabylonJS editor, where the host will fail to load with the error "no scene available to load asset container to” after running the scene in the editor.

This happens because - when you don't pass in a scene - BabylonJS will attempt to get the last scene opened by the engine. This field is evidently cleared by the editor after the 'play' button is pressed to run the scene - in other words, it's not reliably set.

*Testing done:*
Unit tests pass, `npm run start-babylon-demos` was run and demos were checked


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
