### PR TITLE
Ensure webpack hot-reload files generate to ignored subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 docs/
 demo-credentials.js
 **/dist/
+.hot-reload/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,8 @@ module.exports = {
       umdNamedDefine: true,
     },
     globalObject: '(typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this)',
+    hotUpdateChunkFilename: '.hot-reload/[id].[fullhash].hot-update.js',
+    hotUpdateMainFilename: '.hot-reload/[runtime].[fullhash].hot-update.json',
   },
   plugins: [
     new webpack.BannerPlugin({


### PR DESCRIPTION
### Issue #, if available:
NA

### Description of changes:

#### Previous behavior:
If a developer edited JS files while the webpack dev server was running, "hot-reload" files would be generated to the root folder of the repository. These files would remain even after the server was stopped. They were not ignored by Git which would mark them as new files to commit.

#### New behavior:
The hot reload files are now generated to a ".hot-reload" folder. That folder has been added to .gitignore.

### How to test
 
1. Checkout this branch
2. Run `git clean -xfd` to clear out untracked files you may have locally
3. Run `npm install`
4. Run `npm run start-babylon` which starts the dev server
5. Make an edit to any .js file in the repo and save it
6. Note that hot-reload files get written to a ".hot-reload" directory.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
