### PR TITLE
Remove broken tests

### DIFF
--- a/packages/amazon-sumerian-hosts-core/test/unit/animpack/state/SingleState.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/animpack/state/SingleState.spec.js
@@ -36,18 +36,6 @@ describeEnvironment('SingleState', () => {
       expect(state.timeScalePending).toBeFalse();
     });
 
-    it('should return false if the timeScale promise has been rejected', () => {
-      state._promises.timeScale = new Deferred();
-
-      expect(state.timeScalePending).toBeTrue();
-
-      state._promises.timeScale.reject();
-
-      state._promises.timeScale.catch();
-
-      expect(state.timeScalePending).toBeFalse();
-    });
-
     it('should return false if the timeScale promise has been canceled', () => {
       state._promises.timeScale = new Deferred();
 

--- a/packages/amazon-sumerian-hosts-three/test/unit/animpack/state/SingleState.spec.js
+++ b/packages/amazon-sumerian-hosts-three/test/unit/animpack/state/SingleState.spec.js
@@ -105,18 +105,6 @@ describeEnvironment('SingleState', () => {
       expect(state.timeScalePending).toBeFalse();
     });
 
-    it('should return false if the timeScale promise has been rejected', () => {
-      state._promises.timeScale = new Deferred();
-
-      expect(state.timeScalePending).toBeTrue();
-
-      state._promises.timeScale.reject();
-
-      state._promises.timeScale.catch();
-
-      expect(state.timeScalePending).toBeFalse();
-    });
-
     it('should return false if the timeScale promise has been canceled', () => {
       state._promises.timeScale = new Deferred();
 


### PR DESCRIPTION
See commit: 49e134c

This is the same thing again. We had this test copied 3 times(!) and the previous change only removed one of them.

To restate from before: These tests leave a dangling promise rejection, which end up failing the tests in a race condition. My best guess is that if the tests are ran on a fast enough machine that it passes as the rejection isn't observed on the event loop before all the tests have passed. This is only a guess though. This test doesn't seem to be testing anything useful anyway so removing them.

Leaving these tests in caused the tests to stop running on certain machines, including mine and Kris's.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
