### PR TITLE
Tune package exports and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,50 @@ It defines a Javascript API for managing animations, synthesizing and playing sp
 * [Amazon-Sumerian-Hosts-Three](packages/amazon-sumerian-hosts-three) is an integration of the core library with [three.js](https://threejs.org/)
 * [Amazon-Sumerian-Hosts-Babylon](packages/amazon-sumerian-hosts-babylon) is an integration of the core library with [Babylon.js](https://www.babylonjs.com/)
 
-You can clone the repository to obtain glTF character animation assets (located in the [examples](packages/amazon-sumerian-hosts-babylon/examples/assets/glTF/)) tailored to work well with the Host API. You can use them as-is, modify them in DCC software such as [Blender](https://www.blender.org/) or use them as a guide to develop your own 3D assets.
 
-The easiest way to start using the API is to include the build file that corresponds with the rendering engine you are using. See the Getting Started guide in either [three.js](packages/amazon-sumerian-hosts-three/README.md#getting-started) or [Babylon.js](packages/amazon-sumerian-hosts-babylon/README.md#getting-started) packages for a walkthrough using this method and the [API Documentation](https://aws-samples.github.io/amazon-sumerian-hosts/) for more detailed information on the classes and methods available. Amazon Sumerian Hosts has all three of its packages published to [npm](https://www.npmjs.com/), so alternatively you can install in an existing Node.js project by running `npm install --save @amazon-sumerian-hosts/core @amazon-sumerian-hosts/three @amazon-sumerian-hosts/babylon`.
-
-If you'd like to pull the gitub repository and create your own build, see [Building the Repository](#Building-the-Repository) for prerequisites and instructions on how to do that.
-
-## License
+# License
 
 This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) file. The assets within examples folders are licensed under the CC-BY-4.0 License. See the [LICENSE](packages/amazon-sumerian-hosts-babylon/examples/assets/LICENSE) file.
 <br/><br/>
+
+# Usage
+
+## Getting started using the sample project
+
+There are a number of ways to use Amazon Sumerian Hosts in your own projects
+
+The easiest way to get started using the hosts is by starting with our sample project which integration amazon-sumerian-hosts-babylon with the Babylon.js editor and publishing to the web using AWS Amplify *TODO*
+
+
+## Integrating into a three.js or babylon.js project
+
+If you do not wish to use the Babylon.js editor, you may install the integration for three.js or babylon.js using one of the following commands:
+
+`npm install --save @amazon-sumerian-hosts/three` for three.js
+
+`npm install --save @amazon-sumerian-hosts/babylon` for babylon.js
+
+The integration test and demos in this repository will get you started in using these libraries.
+
+These integrations each use package.json exports to publish both ESM modules and a bundled CommonJS module for broad compatibility
+
+See the Getting Started guide in either [three.js](packages/amazon-sumerian-hosts-three/README.md#getting-started) or [Babylon.js](packages/amazon-sumerian-hosts-babylon/README.md#getting-started) packages for a walkthrough using this method and the [API Documentation](https://aws-samples.github.io/amazon-sumerian-hosts/) for more detailed information on the classes and methods available. 
+
+
+## Integrating into your own web 3d engine.
+
+The @amazon-sumerian-hosts/core package provides the core host functionality that can be integrated into any engine.
+
+If you'd like to extend hosts to support another Javascript rendering engine, create a new folder inside `packages` with the name of the engine you're adding support for. 
+Extend any host modules that need to use resources specific to your rendering engine. See the [`Amazon-Sumerian-Hosts-Three`](packages/amazon-sumerian-hosts-three/src/three.js/) and [`Amazon-Sumerian-Hosts-Babylon`](packages/amazon-sumerian-hosts-babylon/src/Babylon.js/) package folders for examples of files you'll likely need to include. Generally you will need to extend `Messenger` if your engine has an event/messaging system, `HostObject` if your engine keeps track of time and delta time, `AnimationFeature` and `SingleState` if your engine has an animation system, and `TextToSpeechFeature` and `Speech` if your engine has an audio system. Update `webpack.config.js` to add a new config for the engine you're adding support for.
+
+# Graphical Assets
+
+You can clone the repository to obtain glTF character animation assets (located in the [examples](packages/amazon-sumerian-hosts-babylon/examples/assets/glTF/)) tailored to work well with the Host API. You can use them as-is, modify them in DCC software such as [Blender](https://www.blender.org/) or use them as a guide to develop your own 3D assets.
+
+
+If you'd like to pull the gitub repository and create your own build, see [Building the Repository](#Building-the-Repository) for prerequisites and instructions on how to do that.
+
 
 # [Building the Repository](#Building-the-Repository)
 
@@ -26,7 +60,8 @@ This library is licensed under the MIT-0 License. See the [LICENSE](LICENSE) fil
 - Install [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
  - At least Node.js 15 and npm 7, but is tested with Node.js 16 and npm 8. 
 
-## Installation
+
+## Cloning
 
 1. Create and cd into the folder you want to clone the repository to.
 ```
@@ -39,7 +74,7 @@ cd amazon-sumerian-hosts
 git clone https://github.com/aws-samples/amazon-sumerian-hosts.git
 ```
 
-3. Install dev dependencies
+3. Install dependencies
 ```
 npm install
 ```
@@ -50,9 +85,6 @@ Generate build files using the following command
 npm run build
 ```
 This will simultaenously build all of the packages in the repository. You will now have new build files in the `dist` directory for each package. 
-
-If you'd like to extend hosts to support another Javascript rendering engine, create a new folder inside `packages` with the name of the engine you're adding support for. 
-Extend any host modules that need to use resources specific to your rendering engine. See the [`Amazon-Sumerian-Hosts-Three`](packages/amazon-sumerian-hosts-three/src/three.js/) and [`Amazon-Sumerian-Hosts-Babylon`](packages/amazon-sumerian-hosts-babylon/src/Babylon.js/) package folders for examples of files you'll likely need to include. Generally you will need to extend `Messenger` if your engine has an event/messaging system, `HostObject` if your engine keeps track of time and delta time, `AnimationFeature` and `SingleState` if your engine has an animation system, and `TextToSpeechFeature` and `Speech` if your engine has an audio system. Update `webpack.common.js` to add a new config for the engine you're adding support for.
 
 ## Testing
 This repository has three methods of testing: unit tests, integration tests, and example file validation.

--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
     "start-babylon": "ENGINE=babylon NODE_ENV=development webpack-dev-server"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.4",
-    "@babel/preset-env": "^7.8.4",
-    "babel-loader": "^8.2.3",
-    "babel-polyfill": "^6.26.0",
     "eslint": "^8.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.10.0",

--- a/packages/amazon-sumerian-hosts-babylon/package.json
+++ b/packages/amazon-sumerian-hosts-babylon/package.json
@@ -13,15 +13,17 @@
     "url": "https://github.com/aws-samples/amazon-sumerian-hosts.git"
   },
   "main": "./src/Babylon.js/index.js",
+  "exports": {
+    "import": "./src/Babylon.js/index.js",
+    "require": "./dist/host.babylon.js"
+  },
   "scripts": {
   },
   "dependencies": {
-    "@amazon-sumerian-hosts/core": "^2.0.0"
+    "@amazon-sumerian-hosts/core": "^2.0.0",
+    "aws-sdk": "^2.1094.0"
   },
   "peerDependencies": {
     "babylonjs": "=4.2.1"
-  },
-  "dependencies": {
-    "aws-sdk": "^2.1094.0"
   }
 }

--- a/packages/amazon-sumerian-hosts-core/package.json
+++ b/packages/amazon-sumerian-hosts-core/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/aws-samples/amazon-sumerian-hosts.git"
   },
   "main": "./src/core/index.js",
+  "exports": {
+    "import": "./src/core/index.js",
+    "require": "./dist/host.core.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "docs": "jsdoc -c jsdoc.conf.json"

--- a/packages/amazon-sumerian-hosts-three/package.json
+++ b/packages/amazon-sumerian-hosts-three/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/aws-samples/amazon-sumerian-hosts.git"
   },
   "main": "./src/three.js/index.js",
+  "exports": {
+    "import": "./src/three.js/index.js",
+    "require": "./dist/host.three.js"
+  },
   "scripts": {
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = {
   devtool: process.env.NODE_ENV === "development" ? "source-map" : undefined,
   entry: {
     'host.core': {
-      import: ['babel-polyfill', './packages/amazon-sumerian-hosts-core/src/core/index.js'],
+      import: './packages/amazon-sumerian-hosts-core/src/core/index.js',
       filename: "./packages/amazon-sumerian-hosts-core/dist/[name].js",
     },
     'host.babylon': {


### PR DESCRIPTION
I've updated the package.json for the published packages to provide both require(commonjs) and import(ESM) exports.

The idea here being that consumers of this package through NPM will default to `import` if they support it.
We generally expect applications using the library to bundle the source into their own applications, where they have full control over transpiling, chunking, polyfilling, etc according to their needs.

The .dist.js files are common.js files that are consumable directly in the browser. This can be used by applications that don't wish to use a bundler for their webapplication. It can also be used by any other consumer that is not compatible with ESM modules and must use commonjs for whatever reason.

The `main` entry in the package.json files is the old-style to specify this. This will work for those using versions of Node older than v13.

I've also updated the README a bit to provide better guidance around usage, that is starting with it should be npm installed and not forked unless someone is actually contributing to the repo. I've mentioned our new sample application, but of course this needs to be expanded on when that is ready.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
