### PR TITLE
Fix mangling; additional HostObject utility functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-webpack": "^5.0.0",
     "prettier": "^1.19.1",
     "regenerator-runtime": "^0.13.5",
+    "terser-webpack-plugin": "^5.3.1",
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.3",

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -182,7 +182,7 @@ class HostObject extends CoreHostObject {
   }
 
   /**
-   * Loads the animations speci
+   * Loads the animations for a host character
    *
    * @param {Babylon.Scene} scene
    * @param {Babylon.Mesh} characterMesh The root mesh of the character model
@@ -694,7 +694,7 @@ const host = await HOST.HostUtils.createHost(scene, characterConfig, pollyConfig
 
   /**
  *
- * @returns {string[]} An array of identifies that can be used with getCharacterConfiguration
+ * @returns {string[]} An array of characterId's that can be used with getCharacterConfig
  */
   static getAvailableCharacters() {
     return [...characterTypeMap.keys()];

--- a/packages/amazon-sumerian-hosts-babylon/test/unit/HostObject.spec.js
+++ b/packages/amazon-sumerian-hosts-babylon/test/unit/HostObject.spec.js
@@ -166,31 +166,31 @@ describeEnvironment('HostObject', (options = {}) => {
     });
 
     it('has correct animStandIdleUrl property', () => {
-      expect(config.animStandIdleUrl).toEqual(`${animAssetsBase}stand_idle.glb`);
+      expect(config.animUrls.animStandIdleUrl).toEqual(`${animAssetsBase}stand_idle.glb`);
     });
 
     it('has correct animLipSyncUrl property', () => {
-      expect(config.animLipSyncUrl).toEqual(`${animAssetsBase}lipsync.glb`);
+      expect(config.animUrls.animLipSyncUrl).toEqual(`${animAssetsBase}lipsync.glb`);
     });
 
     it('has correct animGestureUrl property', () => {
-      expect(config.animGestureUrl).toEqual(`${animAssetsBase}gesture.glb`);
+      expect(config.animUrls.animGestureUrl).toEqual(`${animAssetsBase}gesture.glb`);
     });
 
     it('has correct animEmoteUrl property', () => {
-      expect(config.animEmoteUrl).toEqual(`${animAssetsBase}emote.glb`);
+      expect(config.animUrls.animEmoteUrl).toEqual(`${animAssetsBase}emote.glb`);
     });
 
     it('has correct animFaceIdleUrl property', () => {
-      expect(config.animFaceIdleUrl).toEqual(`${animAssetsBase}face_idle.glb`);
+      expect(config.animUrls.animFaceIdleUrl).toEqual(`${animAssetsBase}face_idle.glb`);
     });
 
     it('has correct animBlinkUrl property', () => {
-      expect(config.animBlinkUrl).toEqual(`${animAssetsBase}blink.glb`);
+      expect(config.animUrls.animBlinkUrl).toEqual(`${animAssetsBase}blink.glb`);
     });
 
     it('has correct animPointOfInterestUrl property', () => {
-      expect(config.animPointOfInterestUrl).toEqual(`${animAssetsBase}poi.glb`);
+      expect(config.animUrls.animPointOfInterestUrl).toEqual(`${animAssetsBase}poi.glb`);
     });
   });
 
@@ -198,5 +198,18 @@ describeEnvironment('HostObject', (options = {}) => {
     expect(() => {
       HostObject.getCharacterConfig('assets', 'Batman');
     }).toThrowError(Error, '"Batman" is not a supported character ID.');
+  });
+
+  describe('getAvailableCharacters()', () => {
+    const hosts = HostObject.getAvailableCharacters();
+
+    it('contains characters we expect', () => {
+      expect(hosts).toContain('Cristine');
+      expect(hosts).toContain('Wes');
+    });
+
+    it('does not contain characters we do not expect', () => {
+      expect(hosts).not.toContain('Batman');
+    });
   });
 });

--- a/packages/demos-babylon/src/customCharacterDemo.js
+++ b/packages/demos-babylon/src/customCharacterDemo.js
@@ -35,13 +35,15 @@ async function createScene() {
     modelUrl: './character-assets/characters/alien/alien.gltf',
     gestureConfigUrl: './character-assets/animations/alien/gesture.json',
     pointOfInterestConfigUrl: './character-assets/animations/alien/poi.json',
-    animStandIdleUrl: './character-assets/animations/alien/stand_idle.glb',
-    animLipSyncUrl: './character-assets/animations/alien/lipsync.glb',
-    animGestureUrl: './character-assets/animations/alien/gesture.glb',
-    animEmoteUrl: './character-assets/animations/alien/emote.glb',
-    animFaceIdleUrl: './character-assets/animations/alien/face_idle.glb',
-    animBlinkUrl: './character-assets/animations/alien/blink.glb',
-    animPointOfInterestUrl: './character-assets/animations/alien/poi.glb',
+    animUrls: {
+      animStandIdleUrl: './character-assets/animations/alien/stand_idle.glb',
+      animLipSyncUrl: './character-assets/animations/alien/lipsync.glb',
+      animGestureUrl: './character-assets/animations/alien/gesture.glb',
+      animEmoteUrl: './character-assets/animations/alien/emote.glb',
+      animFaceIdleUrl: './character-assets/animations/alien/face_idle.glb',
+      animBlinkUrl: './character-assets/animations/alien/blink.glb',
+      animPointOfInterestUrl: './character-assets/animations/alien/poi.glb',
+    },
     lookJoint: 'char:gaze',
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const cognitoIdentityPoolId = require('./demo-credentials');
 
@@ -50,7 +51,7 @@ if(isDevServer) {
 
 module.exports = {
   // Turn on source maps if we aren't doing a production build, so tests and `start` for the examples.
-  devtool: process.env.NODE_ENV === "development" ? "source-map" : undefined,
+  devtool: "source-map",
   entry: {
     'host.core': {
       import: './packages/amazon-sumerian-hosts-core/src/core/index.js',
@@ -106,5 +107,15 @@ module.exports = {
       });
       return middlewares;
     }
-  }
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          keep_classnames: true
+        }
+      }),
+    ],
+  },
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,8 @@ module.exports = {
       return middlewares;
     }
   },
+  // We need to override some of the defaults for the minimization step --
+  // There are issues with mangling otherwise, as logic relies on class names being preserved
   optimization: {
     minimize: true,
     minimizer: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ if(isDevServer) {
 
 module.exports = {
   // Turn on source maps if we aren't doing a production build, so tests and `start` for the examples.
-  devtool: "source-map",
+  devtool: process.env.NODE_ENV === "development" ? "source-map" : undefined,
   entry: {
     'host.core': {
       import: './packages/amazon-sumerian-hosts-core/src/core/index.js',


### PR DESCRIPTION
## Description
This PR adds 3 bits of functionality:

- The first is to fix an issue seen with the BabylonJS editor (which uses require() and pulls in the minified version of the repo) where certain functionality in the HostObject utility scripts rely on class names not being mangled (as they're used to dynamically form and then call function names.) This involves changes to the webpack config to configure the minimization to no longer mangle class names.
- `HostObject.loadAssets` has been separated into `loadCharacterModel` and `loadAnimations`. This is because the plugin needs the former workflow in the editor (to render the model to the currently open scene), and the latter only during runtime.
- `HostObject.getAvailableCharacters()` has been added as a utility function so that the UX can render the available hosts.

## Related Issue \#


## Reviewer Testing Instructions
I am using this in conjunction with the BabylonJS editor plugin to manually test functionality. 

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.