### PR TITLE
Add explicit Babylon import so module import works

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/package.json
+++ b/packages/amazon-sumerian-hosts-babylon/package.json
@@ -24,6 +24,7 @@
     "aws-sdk": "^2.1094.0"
   },
   "peerDependencies": {
-    "babylonjs": "=4.2.1"
+    "babylonjs": ">=4.2.1",
+    "babylonjs-loaders":  ">=4.2.1"
   }
 }

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -6,6 +6,7 @@ import {
   GestureFeature,
 } from '@amazon-sumerian-hosts/core';
 import AWS from 'aws-sdk';
+import * as BABYLON from 'babylonjs';
 import anim from './animpack';
 import aws from './awspack';
 import PointOfInterestFeature from './PointOfInterestFeature';


### PR DESCRIPTION
## Description
The `HostObject` file assumes that the Babylon module will be imported/embedded as an external source file, which throws the error `BABYLON is not defined` when the module is `npm install`ed and then imported.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.