### PR TITLE
Adding language as an optional argument to HostObject.addTextToSpeech

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -571,6 +571,7 @@ class HostObject extends CoreHostObject {
     scene,
     voice,
     engine,
+    language = 'en-US',
     audioJointName = 'char:def_c_neckB'
   ) {
     const joints = host.owner.getDescendants(false);
@@ -581,6 +582,7 @@ class HostObject extends CoreHostObject {
       attachTo: audioJoint,
       voice,
       engine,
+      language,
     });
   }
 


### PR DESCRIPTION
## Description
Adding `language` as a parameter to the static helper method `HostObject.addTextToSpeech`, with a default of `en-US` -- this is somewhat arbitrary, as the [core library actually specifies `en-GB` as a default language if none is specified](https://github.com/aws-samples/amazon-sumerian-hosts/blob/mainline/src/core/awspack/AbstractTextToSpeechFeature.js#L1181). It ultimately [checks to make sure the language is supported by the voice, and will select the voice's default language if not](https://github.com/aws-samples/amazon-sumerian-hosts/blob/b5ee6383b898fcb89c1dda8c907698abbfa74bd2/src/core/awspack/AbstractTextToSpeechFeature.js#L444).

So this is not a dangerous default to set -- in the sense that if we were to pass in `Mizuki` (a voice that only supports the language `ja-JP`) without passing in a language as an argument to override the default, the core library will do the right thing by using `ja-JP` instead of the `en-US` default..

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.