### PR TITLE
remove quote in prettier script to make it work on Winodws OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier 'packages/**/*.js' --write",
+    "format": "prettier packages/**/*.js --write",
     "test": "node ./node_modules/karma/bin/karma start karma.conf.js",
     "build": "npm run format && npm run lint:fix && webpack",
     "build-test": "npm run build build && npm run test",


### PR DESCRIPTION
## Description
When I ran the project in the Windows environment, the prettier script failed since it had the quote which was not recognized by Windows OS.
By removing it, it can work in both Windows and Mac environment.
## Testing
Built the project in Windows 10 instance and local MacOS Catalina.
## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.