### PR TITLE
Configure PR checks to run on Windows and MacOS

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,13 @@ on:
 # This doesn't work in Actions, however, so we set this env var to force the Headless runner
 env:
   TEST_BROWSERS: ChromeHeadless
-  
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
       - name: Initialize CodeQL
@@ -22,8 +25,7 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - run: chromium --version
       - run: npm run build-test
       - name: Perform CodeQL Analysis
+        if: matrix.os == 'ubuntu-latest' # we only need to run this check on one platform
         uses: github/codeql-action/analyze@v1
-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false # continue testing on all platforms even if one fails
     steps:
       - uses: actions/checkout@v2
       - name: Initialize CodeQL


### PR DESCRIPTION
## Description
To avoid issues in the future where code changes prevent the repo from compiling on Windows, I've added it as part of the configuration for the PR-check Github action; this action will be run for each OS specified under `strategy`. Since the majority of the developers use MacOSX, I've added that as well. These jobs run in parallel, so the time taken to run PR checks should not increase by any significant amount.

I've removed the `chromium --version` check as the command is not cross-platform compatible, the version of chrome on the path may not be the chrome the karma-runner is using, and trying to run the right command would add unneeded complexity to the file. Chrome is installed on all OS images by default, and the karma-runner prints out what version it's running with.

You can see an example of the PR action being run on all platforms here: https://github.com/JuliaABurch/amazon-sumerian-hosts/pull/3 (Note that the windows run will fail until  #109 is merged, but I have it passing locally as I pulled in that change to my repo )

## Reviewer Testing Instructions
Github actions are a little tricky to test - I did it on my forked repo after manually enabling actions.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
