### PR TITLE
Fix: do not bundle separate version of babylonJS

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/README.md
+++ b/packages/amazon-sumerian-hosts-babylon/README.md
@@ -23,6 +23,22 @@ This guide steps you through the code of the [examples/babylon.html](examples/ba
 
 ## [Getting started in Babylon.js](#Getting-started-in-Babylon.js) 
 
+## Configuring Webpack
+
+We recommend using a module bundler such as [Webpack](https://webpack.js.org/) to package and distribute your code. As BabylonJS relies on static singletons for certain features, it may be necessary to configure Webpack so that all modules and submodules use the same instance of BabylonJS. Add the following to `module.exports.resolve`:
+
+```
+		resolve: {
+			...
+			modules: ['node_modules'],
+			alias: {
+			    // configure all modules to point at the same instance of BabylonJS
+			    '@babylonjs/core': path.resolve('./node_modules/@babylonjs/core')
+			}
+		},
+
+```
+
 ### Step 1. Adding Script Dependencies
 
 Here we will take a look at the scripts necessary for the example code to function:

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -9,6 +9,7 @@ import {SceneLoader} from '@babylonjs/core/Loading/sceneLoader';
 import {PrecisionDate} from '@babylonjs/core/Misc/precisionDate';
 import {Observable} from '@babylonjs/core/Misc/observable';
 import {AnimationGroup} from '@babylonjs/core/Animations/animationGroup';
+import {RawTexture} from '@babylonjs/core/Materials/Textures/rawTexture';
 import '@babylonjs/loaders';
 import AWS from 'aws-sdk';
 import anim from './animpack';

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/HostObject.js
@@ -9,6 +9,7 @@ import {SceneLoader} from '@babylonjs/core/Loading/sceneLoader';
 import {PrecisionDate} from '@babylonjs/core/Misc/precisionDate';
 import {Observable} from '@babylonjs/core/Misc/observable';
 import {AnimationGroup} from '@babylonjs/core/Animations/animationGroup';
+// eslint-disable-next-line no-unused-vars
 import {RawTexture} from '@babylonjs/core/Materials/Textures/rawTexture';
 import '@babylonjs/loaders';
 import AWS from 'aws-sdk';

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/TextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/TextToSpeechFeature.js
@@ -6,7 +6,6 @@ import {
 } from '@amazon-sumerian-hosts/core';
 import {Sound} from '@babylonjs/core/Audio/sound';
 import {Engine} from '@babylonjs/core/Engines/engine';
-import '@babylonjs/core/Audio/audioSceneComponent';
 import '@babylonjs/core/Audio/audioEngine';
 import Speech from './Speech';
 

--- a/packages/amazon-sumerian-hosts-babylon/test/unit/BabylonHarness.js
+++ b/packages/amazon-sumerian-hosts-babylon/test/unit/BabylonHarness.js
@@ -1,11 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import {Scene} from '@babylonjs/core/scene';
 import {Engine} from '@babylonjs/core/Engines/engine';
 import {Mesh} from '@babylonjs/core/Meshes/mesh';
 // Side-effects only imports allowing Mesh to create default shapes
 import '@babylonjs/core/Meshes/Builders/sphereBuilder';
 
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT-0
 export default function describeBabylonHost(description, fn) {
   describe(`Babylon Host - ${description}`, () => {
     // Canvas

--- a/packages/demos-babylon/src/chatbotDemo.js
+++ b/packages/demos-babylon/src/chatbotDemo.js
@@ -9,7 +9,7 @@ let scene;
 async function createScene() {
   // Create an empty scene. Note: Sumerian Hosts work with both
   // right-hand or left-hand coordinate system for babylon scene
-  scene = new BABYLON.Scene();
+  scene = new Scene();
   scene.useRightHandedSystem = true;
 
   const {shadowGenerator} = DemoUtils.setupSceneEnvironment(scene);

--- a/packages/demos-babylon/src/common/demo-utils.js
+++ b/packages/demos-babylon/src/common/demo-utils.js
@@ -1,4 +1,5 @@
 import {Engine} from '@babylonjs/core/Engines/engine';
+import '@babylonjs/core/Audio/audioEngine';
 import {Color3, Vector3, Angle} from '@babylonjs/core/Maths/math';
 import {DirectionalLight} from '@babylonjs/core/Lights/directionalLight';
 import {ArcRotateCamera} from '@babylonjs/core/Cameras/arcRotateCamera';

--- a/packages/demos-babylon/src/common/demo-utils.js
+++ b/packages/demos-babylon/src/common/demo-utils.js
@@ -1,5 +1,4 @@
 import {Engine} from '@babylonjs/core/Engines/engine';
-import '@babylonjs/core/Audio/audioEngine';
 import {Color3, Vector3, Angle} from '@babylonjs/core/Maths/math';
 import {DirectionalLight} from '@babylonjs/core/Lights/directionalLight';
 import {ArcRotateCamera} from '@babylonjs/core/Cameras/arcRotateCamera';

--- a/packages/demos-babylon/src/customCharacterDemo.js
+++ b/packages/demos-babylon/src/customCharacterDemo.js
@@ -10,7 +10,7 @@ let scene;
 async function createScene() {
   // Create an empty scene. Note: Sumerian Hosts work with both
   // right-hand or left-hand coordinate system for babylon scene
-  scene = new BABYLON.Scene();
+  scene = new Scene();
   scene.useRightHandedSystem = true;
 
   const {shadowGenerator} = DemoUtils.setupSceneEnvironment(scene);

--- a/packages/demos-babylon/src/gesturesDemo.js
+++ b/packages/demos-babylon/src/gesturesDemo.js
@@ -9,7 +9,7 @@ let scene;
 async function createScene() {
   // Create an empty scene. Note: Sumerian Hosts work with both
   // right-hand or left-hand coordinate system for babylon scene
-  scene = new BABYLON.Scene();
+  scene = new Scene();
   scene.useRightHandedSystem = true;
 
   const {shadowGenerator} = DemoUtils.setupSceneEnvironment(scene);

--- a/packages/demos-babylon/src/helloWorldDemo.js
+++ b/packages/demos-babylon/src/helloWorldDemo.js
@@ -9,7 +9,7 @@ let scene;
 async function createScene() {
   // Create an empty scene. Note: Sumerian Hosts work with both
   // right-hand or left-hand coordinate system for babylon scene
-  scene = new BABYLON.Scene();
+  scene = new Scene();
 
   const {shadowGenerator} = DemoUtils.setupSceneEnvironment(scene);
   initUi();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ if(isDevServer) {
 if (!isDevServer) {
   // do not bundle peer dependencies, unless we're running demos
   prodOnlyExternals =     [
+    // eslint-disable-next-line no-unused-vars
     function ({context, request}, callback) {
       if (/^@babylonjs\/core.*$/.test(request)) {
         return callback(null, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ else if (process.env.ENGINE === "babylon") {
 }
 
 let devServerOnlyEntryPoints = {}
+let prodOnlyExternals = [];
 
 if(isDevServer) {
 // Only build the demos & tests if we are running in the dev server
@@ -55,6 +56,31 @@ if(isDevServer) {
       filename: './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/dist/[name].js',
     }
   }
+}
+
+if (!isDevServer) {
+  // do not bundle peer dependencies, unless we're running demos
+  prodOnlyExternals =     [
+    function ({context, request}, callback) {
+      if (/^@babylonjs\/core.*$/.test(request)) {
+        return callback(null, {
+          root: "BABYLON",
+          commonjs: "@babylonjs/core",
+          commonjs2: "@babylonjs/core",
+          amd: "@babylonjs/core"
+        });
+      }
+      else if (/^@babylonjs\/loaders.*$/i.test(request)) {
+        return callback(null, {
+          root: "BABYLON",
+          commonjs: "@babylonjs/loaders",
+          commonjs2: "@babylonjs/loaders",
+          amd: "@babylonjs/loaders"
+        });
+      }
+      callback();
+    },
+  ]
 }
 
 module.exports = {
@@ -130,8 +156,12 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
+    // don't import @babylonjs/core from the submodule's dependencies,
+    // but from the project dependencies
     alias: {
       '@babylonjs/core': path.resolve('./node_modules/@babylonjs/core')
     }
   },
+  externals:
+    [...prodOnlyExternals]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,4 +128,10 @@ module.exports = {
       }),
     ],
   },
+  resolve: {
+    modules: ['node_modules'],
+    alias: {
+      '@babylonjs/core': path.resolve('./node_modules/@babylonjs/core')
+    }
+  },
 }

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -8,6 +8,9 @@ const baseConfig = require("./webpack.config");
 // Removing the output will stop webpack from outputing chunks for the integration test code
 delete baseConfig.output;
 
+// We need external dependencies to be packaged with the tests so that they may run
+delete baseConfig.externals;
+
 module.exports = {
   ...baseConfig,
   plugins: [


### PR DESCRIPTION
## Description
These commits fix a few merge errors that were preventing demos from launching, and configures webpack to do two things:
1. When importing `@babylonjs/core`, look first in the project's `node_modules` instead of the submodule/library's `node_modules` -- this is so the same static instances are returned, eg `Engine.audioContext`, with all of the side-effects needed for our library to run. All projects using `@amazon-sumerian-hosts/babylon` will want to do the same.
2. Strip out `@babylonjs/core` and `babylonjs-loaders` when bundling (the default behavior is otherwise to concatenate all dependencies.) Webpack ignores `peer-dependencies` declared in `package.json`, and we're intended to re-declare them in the `externals: [...]` block. HOWEVER, the demos need `@babylonjs/core` bundled along with their demo code (otherwise it'll be as if `@babylonjs/core` is never imported anywhere in that project) -- thus the conditional inclusion. This behavior is unique to the structure of our monorepo.


## Reviewer Testing Instructions
I've tested this by running the integration tests & demos; pull this PR locally and run `npm run start-babylon` to do the same. I've additionally tested this with projects built with the BabylonJS editor.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.