### PR TITLE
Upgrade Babylon demos to latest version of BJS

### DIFF
--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -213,7 +213,6 @@
 ** @babylonjs/core; version 4.2.1 -- https://github.com/BabylonJS/Babylon.js
 ** @babylonjs/core; version ^5.0.0 -- https://github.com/BabylonJS/Babylon.js
 ** @babylonjs/loaders; version 4.2.1 -- https://github.com/BabylonJS/Babylon.js
-** @babylonjs/loaders; version ^5.0.0 -- https://github.com/BabylonJS/Babylon.js
  
 Apache License 2.0 (Apache)
 Apache License Version 2.0, January 2004 http://www.apache.org/licenses/

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -211,7 +211,9 @@
 ------
 
 ** @babylonjs/core; version 4.2.1 -- https://github.com/BabylonJS/Babylon.js
+** @babylonjs/core; version ^5.0.0 -- https://github.com/BabylonJS/Babylon.js
 ** @babylonjs/loaders; version 4.2.1 -- https://github.com/BabylonJS/Babylon.js
+** @babylonjs/loaders; version ^5.0.0 -- https://github.com/BabylonJS/Babylon.js
  
 Apache License 2.0 (Apache)
 Apache License Version 2.0, January 2004 http://www.apache.org/licenses/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7299,19 +7299,17 @@
       "license": "MIT",
       "devDependencies": {
         "@amazon-sumerian-hosts/babylon": "^2.0.0",
-        "@babylonjs/core": "=4.2.1",
+        "@babylonjs/core": "^5.0.0",
         "copy-webpack-plugin": "^10.2.4"
       }
     },
     "packages/demos-babylon/node_modules/@babylonjs/core": {
-      "version": "4.2.1",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.4.0.tgz",
+      "integrity": "sha512-d3y7HE/5kMRnn2dBab26+kaEpYwlowf/mg1dy+MNufmSQCURaXxSUkalUSWs634XBJVe6K/NAbVszIT8RMXKVg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": ">=1.10.0"
-      },
-      "engines": {
-        "node": "*"
+        "tslib": "^2.3.1"
       }
     },
     "packages/demos-babylon/node_modules/@nodelib/fs.scandir": {
@@ -9000,15 +8998,17 @@
       "version": "file:packages/demos-babylon",
       "requires": {
         "@amazon-sumerian-hosts/babylon": "^2.0.0",
-        "@babylonjs/core": "=4.2.1",
+        "@babylonjs/core": "^5.0.0",
         "copy-webpack-plugin": "^10.2.4"
       },
       "dependencies": {
         "@babylonjs/core": {
-          "version": "4.2.1",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.4.0.tgz",
+          "integrity": "sha512-d3y7HE/5kMRnn2dBab26+kaEpYwlowf/mg1dy+MNufmSQCURaXxSUkalUSWs634XBJVe6K/NAbVszIT8RMXKVg==",
           "dev": true,
           "requires": {
-            "tslib": ">=1.10.0"
+            "tslib": "^2.3.1"
           }
         },
         "@nodelib/fs.scandir": {

--- a/packages/demos-babylon/package.json
+++ b/packages/demos-babylon/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "@amazon-sumerian-hosts/babylon": "^2.0.0",
-    "@babylonjs/core": "=4.2.1",
+    "@babylonjs/core": "^5.0.0",
     "copy-webpack-plugin": "^10.2.4"
   }
 }

--- a/packages/demos-babylon/src/customCharacterDemo.html
+++ b/packages/demos-babylon/src/customCharacterDemo.html
@@ -21,7 +21,7 @@
     <div id="mainScreen" class="screen loading">
       <canvas id="renderCanvas"></canvas>
 
-      <div id="uiPanel">
+      <div id="uiPanel" class="panel">
         <textarea id="speechText" rows="8">Hello. I am a custom host character. Although I have a different skeleton and different animations than the other Sumerian hosts, I still have all the same capabilities!</textarea>
         <button id="speakButton">Speak</button>
       </div>

--- a/packages/demos-babylon/src/gesturesDemo.html
+++ b/packages/demos-babylon/src/gesturesDemo.html
@@ -21,7 +21,7 @@
     <div id="mainScreen" class="screen loading">
       <canvas id="renderCanvas"></canvas>
 
-      <div id="uiPanel" class="hide">
+      <div id="uiPanel" class="hide panel">
         <label for="gestureSelect">Gestures</label>
         <select id="gestureSelect">
           <option></option>

--- a/packages/demos-babylon/src/helloWorldDemo.html
+++ b/packages/demos-babylon/src/helloWorldDemo.html
@@ -21,7 +21,7 @@
     <div id="mainScreen" class="screen loading">
       <canvas id="renderCanvas"></canvas>
 
-      <div id="uiPanel">
+      <div id="uiPanel" class="panel">
         <textarea id="speechText" rows="8">Hello. I'm Cristine, a Sumerian host. It's nice to meet you.</textarea>
         <button id="speakButton">Speak</button>
       </div>


### PR DESCRIPTION
## Description
Prior to this PR, the BabylonJS demos in the `demos-babylon` package were using BabylonJS version 4.2.1. The package has now been updated to use BJS v5.0.0 or later.

This PR also fixes a minor visual bug with the UI panel in some of the demos (missing padding and missing panel translucent background).

## Related Issue \#
n/a

## Reviewer Testing Instructions
1. Run the BJS demos using `npm run start-babylon`.
2. Observe that the demos work exactly like before.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.