### PR TITLE
add browserslist eslint check for compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "extends": [
     "airbnb",
     "prettier",
-    "plugin:jasmine/recommended"
+    "plugin:jasmine/recommended",
+    "plugin:compat/recommended"
   ],
   "plugins": [
     "prettier",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ const TEST_BROWSERS =
     : ['Chrome'];
 console.log(`TEST_BROWSERS=${TEST_BROWSERS.join(',')}`);
 
-module.exports =function(config) {
+module.exports = function(config) {
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-config-airbnb": "^18.0.1",
         "eslint-config-prettier": "^6.10.0",
         "eslint-import-resolver-webpack": "^0.12.1",
+        "eslint-plugin-compat": "^4.0.2",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-jasmine": "^4.1.0",
         "eslint-plugin-node": "^11.0.0",
@@ -179,6 +180,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
+      "dev": true
+    },
+    "node_modules/@mdn/browser-compat-data": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
+      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg==",
       "dev": true
     },
     "node_modules/@socket.io/base64-arraybuffer": {
@@ -886,6 +893,21 @@
         "inherits": "2.0.1"
       }
     },
+    "node_modules/ast-metadata-inferer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "dev": true,
+      "dependencies": {
+        "@mdn/browser-compat-data": "^3.3.14"
+      }
+    },
+    "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+      "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+      "dev": true
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -1253,9 +1275,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true,
       "funding": [
         {
@@ -1582,6 +1604,17 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.3.tgz",
+      "integrity": "sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-pure": {
       "version": "3.22.0",
@@ -2296,6 +2329,113 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-compat": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
+      "integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
+      "dev": true,
+      "dependencies": {
+        "@mdn/browser-compat-data": "^4.1.5",
+        "ast-metadata-inferer": "^0.7.0",
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001304",
+        "core-js": "^3.16.2",
+        "find-up": "^5.0.0",
+        "lodash.memoize": "4.1.2",
+        "semver": "7.3.5"
+      },
+      "engines": {
+        "node": ">=9.x"
+      },
+      "peerDependencies": {
+        "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -4360,6 +4500,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4393,6 +4539,18 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-it": {
@@ -7183,6 +7341,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -7208,6 +7372,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/amazon-sumerian-hosts-babylon": {
@@ -7636,6 +7812,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
+      "dev": true
+    },
+    "@mdn/browser-compat-data": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
+      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg==",
       "dev": true
     },
     "@socket.io/base64-arraybuffer": {
@@ -8263,6 +8445,23 @@
         }
       }
     },
+    "ast-metadata-inferer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.7.0.tgz",
+      "integrity": "sha512-OkMLzd8xelb3gmnp6ToFvvsHLtS6CbagTkFQvQ+ZYFe3/AIl9iKikNR9G7pY3GfOR/2Xc222hwBjzI7HLkE76Q==",
+      "dev": true,
+      "requires": {
+        "@mdn/browser-compat-data": "^3.3.14"
+      },
+      "dependencies": {
+        "@mdn/browser-compat-data": {
+          "version": "3.3.14",
+          "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz",
+          "integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
+          "dev": true
+        }
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -8570,9 +8769,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true
     },
     "catharsis": {
@@ -8835,6 +9034,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.3.tgz",
+      "integrity": "sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==",
       "dev": true
     },
     "core-js-pure": {
@@ -9542,6 +9747,76 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-plugin-compat": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-4.0.2.tgz",
+      "integrity": "sha512-xqvoO54CLTVaEYGMzhu35Wzwk/As7rCvz/2dqwnFiWi0OJccEtGIn+5qq3zqIu9nboXlpdBN579fZcItC73Ycg==",
+      "dev": true,
+      "requires": {
+        "@mdn/browser-compat-data": "^4.1.5",
+        "ast-metadata-inferer": "^0.7.0",
+        "browserslist": "^4.16.8",
+        "caniuse-lite": "^1.0.30001304",
+        "core-js": "^3.16.2",
+        "find-up": "^5.0.0",
+        "lodash.memoize": "4.1.2",
+        "semver": "7.3.5"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -11092,6 +11367,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11119,6 +11400,15 @@
       "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "markdown-it": {
@@ -13266,6 +13556,12 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -13285,6 +13581,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "compile-ts": "tsc --build --verbose",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier packages/**/*.js --write",
+    "format": "prettier *.js packages/**/*.js --write",
     "test": "node ./node_modules/karma/bin/karma start karma.conf.js",
     "build": "npm run format && npm run lint:fix && npm run compile-ts && webpack",
     "build-test": "npm run build && npm run test",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.10.0",
     "eslint-import-resolver-webpack": "^0.12.1",
+    "eslint-plugin-compat": "^4.0.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jasmine": "^4.1.0",
     "eslint-plugin-node": "^11.0.0",
@@ -51,11 +52,19 @@
     "karma-webpack": "^5.0.0",
     "prettier": "^1.19.1",
     "regenerator-runtime": "^0.13.5",
-    "typescript": "^4.6.3",
     "terser-webpack-plugin": "^5.3.1",
+    "typescript": "^4.6.3",
     "webpack": "^5.67.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.3",
     "webpack-merge": "^5.8.0"
-  }
+  },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 ChromeAndroid versions",
+    "last 2 FirefoxAndroid versions",
+    "last 2 iOS versions"
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,99 +8,107 @@ const TerserPlugin = require('terser-webpack-plugin');
 const cognitoIdentityPoolId = require('./demo-credentials');
 
 // If we are running an interactive devserver
-const isDevServer = process.env.ENGINE || process.env.NODE_ENV === "development";
-
+const isDevServer =
+  process.env.ENGINE || process.env.NODE_ENV === 'development';
 
 // By default, devServer will open slash
 // but we have build scripts for core and each engine
-let webpackOpenUrls = ["/"];
+let webpackOpenUrls = ['/'];
 
-if (process.env.ENGINE === "core") {
-  webpackOpenUrls = ['/packages/amazon-sumerian-hosts-core/test/integration_test/core/'];
-}
-else if (process.env.ENGINE === "three") {
-  webpackOpenUrls = ['/packages/amazon-sumerian-hosts-three/examples/three.html', '/packages/amazon-sumerian-hosts-three/test/integration_test/three.js/'];
-}
-else if (process.env.ENGINE === "babylon") {
-  webpackOpenUrls = ['/packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/', '/packages/demos-babylon/src/'];
+if (process.env.ENGINE === 'core') {
+  webpackOpenUrls = [
+    '/packages/amazon-sumerian-hosts-core/test/integration_test/core/',
+  ];
+} else if (process.env.ENGINE === 'three') {
+  webpackOpenUrls = [
+    '/packages/amazon-sumerian-hosts-three/examples/three.html',
+    '/packages/amazon-sumerian-hosts-three/test/integration_test/three.js/',
+  ];
+} else if (process.env.ENGINE === 'babylon') {
+  webpackOpenUrls = [
+    '/packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/',
+    '/packages/demos-babylon/src/',
+  ];
 }
 
-let devServerOnlyEntryPoints = {}
+let devServerOnlyEntryPoints = {};
 let prodOnlyExternals = [];
 
-if(isDevServer) {
-// Only build the demos & tests if we are running in the dev server
+if (isDevServer) {
+  // Only build the demos & tests if we are running in the dev server
   devServerOnlyEntryPoints = {
     helloWorldDemo: {
       import: './packages/demos-babylon/src/helloWorldDemo.js',
-      filename: "./packages/demos-babylon/dist/[name].js",
+      filename: './packages/demos-babylon/dist/[name].js',
     },
     gesturesDemo: {
       import: './packages/demos-babylon/src/gesturesDemo.js',
-      filename: "./packages/demos-babylon/dist/[name].js",
+      filename: './packages/demos-babylon/dist/[name].js',
     },
     customCharacterDemo: {
       import: './packages/demos-babylon/src/customCharacterDemo.js',
-      filename: "./packages/demos-babylon/dist/[name].js",
+      filename: './packages/demos-babylon/dist/[name].js',
     },
     chatbotDemo: {
       import: './packages/demos-babylon/src/chatbotDemo.js',
-      filename: "./packages/demos-babylon/dist/[name].js",
+      filename: './packages/demos-babylon/dist/[name].js',
     },
     textToSpeechTest: {
-      import: './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/babylon.texttospeech.js',
-      filename: './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/dist/[name].js',
+      import:
+        './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/babylon.texttospeech.js',
+      filename:
+        './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/dist/[name].js',
     },
     animationTest: {
-      import: './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/babylon.animation.js',
-      filename: './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/dist/[name].js',
-    }
-  }
-}
-
-if (!isDevServer) {
+      import:
+        './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/babylon.animation.js',
+      filename:
+        './packages/amazon-sumerian-hosts-babylon/test/integration_test/Babylon.js/dist/[name].js',
+    },
+  };
+} else {
   // do not bundle peer dependencies, unless we're running demos
-  prodOnlyExternals =     [
+  prodOnlyExternals = [
     // eslint-disable-next-line no-unused-vars
-    function ({context, request}, callback) {
+    function({context, request}, callback) {
       if (/^@babylonjs\/core.*$/.test(request)) {
         return callback(null, {
-          root: "BABYLON",
-          commonjs: "@babylonjs/core",
-          commonjs2: "@babylonjs/core",
-          amd: "@babylonjs/core"
+          root: 'BABYLON',
+          commonjs: '@babylonjs/core',
+          commonjs2: '@babylonjs/core',
+          amd: '@babylonjs/core',
         });
-      }
-      else if (/^@babylonjs\/loaders.*$/i.test(request)) {
+      } else if (/^@babylonjs\/loaders.*$/i.test(request)) {
         return callback(null, {
-          root: "BABYLON",
-          commonjs: "@babylonjs/loaders",
-          commonjs2: "@babylonjs/loaders",
-          amd: "@babylonjs/loaders"
+          root: 'BABYLON',
+          commonjs: '@babylonjs/loaders',
+          commonjs2: '@babylonjs/loaders',
+          amd: '@babylonjs/loaders',
         });
       }
       callback();
     },
-  ]
+  ];
 }
 
 module.exports = {
   // Turn on source maps if we aren't doing a production build, so tests and `start` for the examples.
-  devtool: process.env.NODE_ENV === "development" ? "source-map" : undefined,
+  devtool: process.env.NODE_ENV === 'development' ? 'source-map' : undefined,
   entry: {
     'host.core': {
       import: './packages/amazon-sumerian-hosts-core/src/core/index.js',
-      filename: "./packages/amazon-sumerian-hosts-core/dist/[name].js",
+      filename: './packages/amazon-sumerian-hosts-core/dist/[name].js',
     },
     'host.babylon': {
-      import: './packages/amazon-sumerian-hosts-babylon/src/Babylon.js/index.js',
-      filename: "./packages/amazon-sumerian-hosts-babylon/dist/[name].js",
+      import:
+        './packages/amazon-sumerian-hosts-babylon/src/Babylon.js/index.js',
+      filename: './packages/amazon-sumerian-hosts-babylon/dist/[name].js',
     },
     'host.three': {
       import: './packages/amazon-sumerian-hosts-three/src/three.js/index.js',
-      filename: "./packages/amazon-sumerian-hosts-three/dist/[name].js",
+      filename: './packages/amazon-sumerian-hosts-three/dist/[name].js',
     },
-    ...devServerOnlyEntryPoints
+    ...devServerOnlyEntryPoints,
   },
   output: {
     filename: '[name].js',
@@ -110,7 +118,8 @@ module.exports = {
       type: 'umd',
       umdNamedDefine: true,
     },
-    globalObject: '(typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this)',
+    globalObject:
+      '(typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this)',
     hotUpdateChunkFilename: '.hot-reload/[id].[fullhash].hot-update.js',
     hotUpdateMainFilename: '.hot-reload/[runtime].[fullhash].hot-update.json',
   },
@@ -124,7 +133,7 @@ module.exports = {
     devMiddleware: {
       // HTML files aren't fully modeled in webpack and may refer to on-dsk files
       // So let's make sure these get written out when watching
-      writeToDisk: true
+      writeToDisk: true,
     },
     open: webpackOpenUrls,
     liveReload: true,
@@ -138,10 +147,10 @@ module.exports = {
       // At some point we may move all the tests to be Webpack entry points and this could be easier
       // But this makes things straight forward to use from our raw HTML files
       devServer.app.get('/devConfig.json', (_, res) => {
-        res.json({ cognitoIdentityPoolId });
+        res.json({cognitoIdentityPoolId});
       });
       return middlewares;
-    }
+    },
   },
   // We need to override some of the defaults for the minimization step --
   // There are issues with mangling otherwise, as logic relies on class names being preserved
@@ -150,8 +159,8 @@ module.exports = {
     minimizer: [
       new TerserPlugin({
         terserOptions: {
-          keep_classnames: true
-        }
+          keep_classnames: true,
+        },
       }),
     ],
   },
@@ -160,9 +169,9 @@ module.exports = {
     // don't import @babylonjs/core from the submodule's dependencies,
     // but from the project dependencies
     alias: {
-      '@babylonjs/core': path.resolve('./node_modules/@babylonjs/core')
-    }
+      '@babylonjs/core': path.resolve('./node_modules/@babylonjs/core'),
+    },
   },
-  externals:
-    [...prodOnlyExternals]
-}
+  externals: [...prodOnlyExternals],
+  target: 'browserslist',
+};

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -3,7 +3,7 @@
 
 // This file extends the base webpack with some stuff so Karma can run the tests
 const webpack = require('webpack');
-const baseConfig = require("./webpack.config");
+const baseConfig = require('./webpack.config');
 
 // Removing the output will stop webpack from outputing chunks for the integration test code
 delete baseConfig.output;
@@ -20,5 +20,5 @@ module.exports = {
     new webpack.ProvidePlugin({
       THREE: 'three',
     }),
-  ]
+  ],
 };


### PR DESCRIPTION
## Description of changes:
- Added the `eslint` to check the compatibility of browsers. 
- Set last 2 versions of Chrome, FireFox and Safari for desktop and last 2 versions of ChromeAndroid, FireFoxAndroid and IOS Safari support.

## Test
- Run `npx browserslist` to see the support browsers with current config.
- Run `npm run build`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
