### PR TITLE
Catch the Lex error since Lex only supports 15s speech

### DIFF
--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -250,12 +250,9 @@ class LexFeature extends Messenger {
 
     return this._processWithAudio(result, this._audioContext.sampleRate).catch(
       error => {
-        console.error(
-          `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`
-        );
-        throw new Error(
-          `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`
-        );
+        let errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;
+        console.error(errorMessage);
+        throw new Error(errorMessage);
       }
     );
   }

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -247,7 +247,6 @@ class LexFeature extends Messenger {
     }
 
     this.emit(this.constructor.EVENTS.recordEnd);
-
     return this._processWithAudio(result, this._audioContext.sampleRate).catch(
       error => {
         let errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -135,7 +135,6 @@ class LexFeature extends Messenger {
       });
     }).then(data => {
       this.emit(this.constructor.EVENTS.lexResponseReady, data);
-
       return data;
     });
   }
@@ -249,7 +248,16 @@ class LexFeature extends Messenger {
 
     this.emit(this.constructor.EVENTS.recordEnd);
 
-    return this._processWithAudio(result, this._audioContext.sampleRate);
+    return this._processWithAudio(result, this._audioContext.sampleRate).catch(
+      error => {
+        console.error(
+          `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`
+        );
+        throw new Error(
+          `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`
+        );
+      }
+    );
   }
 
   /**

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -139,7 +139,7 @@ class LexFeature extends Messenger {
         return data;
       })
       .catch(error => {
-        let errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;
+        const errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;
         console.error(errorMessage);
         throw new Error(errorMessage);
       });

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -133,10 +133,16 @@ class LexFeature extends Messenger {
         }
         return resolve(data);
       });
-    }).then(data => {
-      this.emit(this.constructor.EVENTS.lexResponseReady, data);
-      return data;
-    });
+    })
+      .then(data => {
+        this.emit(this.constructor.EVENTS.lexResponseReady, data);
+        return data;
+      })
+      .catch(error => {
+        let errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;
+        console.error(errorMessage);
+        throw new Error(errorMessage);
+      });
   }
 
   _validateConfig(config) {
@@ -247,13 +253,7 @@ class LexFeature extends Messenger {
     }
 
     this.emit(this.constructor.EVENTS.recordEnd);
-    return this._processWithAudio(result, this._audioContext.sampleRate).catch(
-      error => {
-        let errorMessage = `Error happened during voice recording: ${error}. Please check whether your speech is more than 15s.`;
-        console.error(errorMessage);
-        throw new Error(errorMessage);
-      }
-    );
+    return this._processWithAudio(result, this._audioContext.sampleRate);
   }
 
   /**

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -217,7 +217,7 @@ describeEnvironment('LexFeature', () => {
         botName: 'Bot',
         botAlias: 'Alias',
       });
-      spyOn(lexFeature, '_processWithAudio');
+      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       spyOn(lexFeature, 'emit');
       spyOn(lexFeature, 'beginVoiceRecording').and.callFake(() => {
         lexFeature._recording = true;

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -233,6 +233,7 @@ describeEnvironment('LexFeature', () => {
         botName: 'Bot',
         botAlias: 'Alias',
       });
+      spyOn(lexFeature, '_processWithAudio');
       spyOn(lexFeature, 'emit');
       spyOn(lexFeature, 'beginVoiceRecording').and.callFake(() => {
         lexFeature._recording = true;
@@ -240,7 +241,6 @@ describeEnvironment('LexFeature', () => {
     });
 
     it('should emit end recording message through messenger if messenger is set', async () => {
-      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       lexFeature.beginVoiceRecording();
       lexFeature.endVoiceRecording();
 
@@ -248,7 +248,6 @@ describeEnvironment('LexFeature', () => {
     });
 
     it('should call _processWithAudio function', () => {
-      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       lexFeature.beginVoiceRecording();
       lexFeature.endVoiceRecording();
 

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -129,6 +129,22 @@ describeEnvironment('LexFeature', () => {
         {message: 'TestResponse'}
       );
     });
+
+    it('The error re-thrown from _process should be equal to the customize one.', async () => {
+      mockLexRuntime.postContent.and.callFake(function(param, callback) {
+        callback(new Error('mock error'), {message: 'TestResponse'});
+      });
+      lexFeature = new LexFeature(mockLexRuntime, {
+        botName: 'Bot',
+        botAlias: 'Alias',
+      });
+
+      await expectAsync(
+        lexFeature._process('TestType', 'TestInput', {})
+      ).toBeRejectedWithError(
+        'Error happened during voice recording: Error: mock error. Please check whether your speech is more than 15s.'
+      );
+    });
   });
 
   describe('enableMicInput', () => {
@@ -237,21 +253,6 @@ describeEnvironment('LexFeature', () => {
       lexFeature.endVoiceRecording();
 
       expect(lexFeature._processWithAudio).toHaveBeenCalled();
-    });
-
-    it('The error re-thrown from endVoiceRecording should be equal to the customize one.', () => {
-      spyOn(lexFeature, '_processWithAudio').and.returnValue(
-        Promise.reject('mock error')
-      );
-      lexFeature.beginVoiceRecording();
-
-      try {
-        lexFeature.endVoiceRecording();
-      } catch (error) {
-        expect(error).toEqual(
-          'Error happened during voice recording: mock error. Please check whether your speech is more than 15s.'
-        );
-      }
     });
   });
 });

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -217,7 +217,6 @@ describeEnvironment('LexFeature', () => {
         botName: 'Bot',
         botAlias: 'Alias',
       });
-      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       spyOn(lexFeature, 'emit');
       spyOn(lexFeature, 'beginVoiceRecording').and.callFake(() => {
         lexFeature._recording = true;
@@ -225,6 +224,7 @@ describeEnvironment('LexFeature', () => {
     });
 
     it('should emit end recording message through messenger if messenger is set', async () => {
+      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       lexFeature.beginVoiceRecording();
       lexFeature.endVoiceRecording();
 
@@ -232,10 +232,26 @@ describeEnvironment('LexFeature', () => {
     });
 
     it('should call _processWithAudio function', () => {
+      spyOn(lexFeature, '_processWithAudio').and.returnValue(Promise.resolve());
       lexFeature.beginVoiceRecording();
       lexFeature.endVoiceRecording();
 
       expect(lexFeature._processWithAudio).toHaveBeenCalled();
+    });
+
+    it('The error re-thrown from endVoiceRecording should be equal to the customize one.', () => {
+      spyOn(lexFeature, '_processWithAudio').and.returnValue(
+        Promise.reject('mock error')
+      );
+      lexFeature.beginVoiceRecording();
+
+      try {
+        lexFeature.endVoiceRecording();
+      } catch (error) {
+        expect(error).toEqual(
+          'Error happened during voice recording: mock error. Please check whether your speech is more than 15s.'
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Description
Amazon Lex is limited to 15 seconds for audio input. If a user tries to record more than 15 seconds of audio with our LexFeature an error is thrown. Therefore, this PR is to catch the error from Lex side and re-throw it with a customized string to notice customers if the audio is more than 15s.

Added unit testing to check that the error rethrown from the `endVoiceRecording` was the customized one.

## Reviewer Testing Instructions
- Unit testing.
- ChatBot demo: recording more than 15s audio and watch the Console.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.