### PR TITLE
Fix failing npm install due to incompatible peer dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,8 @@
     "prefer-const": "warn",
     "consistent-return": "off",
     "arrow-body-style": "off",
-    "no-use-before-define": "off"
+    "no-use-before-define": "off",
+    "default-param-last": "off"
   },
   "env": {
     "browser": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "cross-env": "^7.0.3",
         "eslint": "^8.8.0",
-        "eslint-config-airbnb": "^18.0.1",
+        "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^6.10.0",
         "eslint-import-resolver-webpack": "^0.12.1",
         "eslint-plugin-compat": "^4.0.2",
@@ -2219,42 +2219,52 @@
       }
     },
     "node_modules/eslint-config-airbnb": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "dev": true,
       "dependencies": {
-        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-        "eslint-plugin-import": "^2.22.1",
-        "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-react": "^7.21.5",
-        "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0"
       }
     },
-    "node_modules/eslint-config-airbnb/node_modules/eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+    "node_modules/eslint-config-airbnb-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^10.12.0 || >=12.0.0"
       },
       "peerDependencies": {
-        "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
-        "eslint-plugin-import": "^2.22.1"
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -9670,26 +9680,33 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
       },
       "dependencies": {
-        "eslint-config-airbnb-base": {
-          "version": "14.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-          "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
-          "dev": true,
-          "requires": {
-            "confusing-browser-globals": "^1.0.10",
-            "object.assign": "^4.1.2",
-            "object.entries": "^1.1.2"
-          }
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "eslint": "^8.8.0",
-    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^6.10.0",
     "eslint-import-resolver-webpack": "^0.12.1",
     "eslint-plugin-compat": "^4.0.2",

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/AbstractTextToSpeechFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/AbstractTextToSpeechFeature.spec.js
@@ -4,6 +4,7 @@
 /* eslint-disable no-undef */
 /* eslint-disable jasmine/prefer-toHaveBeenCalledWith */
 /* eslint-disable no-underscore-dangle */
+/* eslint-disable no-promise-executor-return */
 import {
   Messenger,
   AbstractTextToSpeechFeature,

--- a/packages/demos-babylon/src/chatbotDemo.js
+++ b/packages/demos-babylon/src/chatbotDemo.js
@@ -1,7 +1,6 @@
 import {HostObject, aws as AwsFeatures} from '@amazon-sumerian-hosts/babylon';
 import {Scene} from '@babylonjs/core/scene';
 import DemoUtils from './common/demo-utils';
-import cognitoIdentityPoolId from '../../../demo-credentials';
 
 let host;
 let scene;
@@ -15,6 +14,11 @@ async function createScene() {
   const {shadowGenerator} = DemoUtils.setupSceneEnvironment(scene);
 
   // ===== Configure the AWS SDK =====
+
+  // This is served by webpack-dev-server and comes from demo-credentials.js in the repo root
+  // If you copy this example, you will substitute in your own cognito Pool ID
+  const config = await (await fetch('/devConfig.json')).json();
+  const cognitoIdentityPoolId = config.cognitoIdentityPoolId;
 
   AWS.config.region = cognitoIdentityPoolId.split(':')[0];
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({

--- a/packages/demos-babylon/src/customCharacterDemo.js
+++ b/packages/demos-babylon/src/customCharacterDemo.js
@@ -2,7 +2,6 @@ import {HostObject} from '@amazon-sumerian-hosts/babylon';
 import {Scene} from '@babylonjs/core/scene';
 import {Vector3} from '@babylonjs/core';
 import DemoUtils from './common/demo-utils';
-import cognitoIdentityPoolId from '../../../demo-credentials';
 
 let host;
 let scene;
@@ -21,6 +20,11 @@ async function createScene() {
   initUi();
 
   // ===== Configure the AWS SDK =====
+
+  // This is served by webpack-dev-server and comes from demo-credentials.js in the repo root
+  // If you copy this example, you will substitute in your own cognito Pool ID
+  const config = await (await fetch('/devConfig.json')).json();
+  const cognitoIdentityPoolId = config.cognitoIdentityPoolId;
 
   AWS.config.region = cognitoIdentityPoolId.split(':')[0];
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({

--- a/packages/demos-babylon/src/gesturesDemo.js
+++ b/packages/demos-babylon/src/gesturesDemo.js
@@ -1,7 +1,6 @@
 import {HostObject} from '@amazon-sumerian-hosts/babylon';
 import {Scene} from '@babylonjs/core/scene';
 import DemoUtils from './common/demo-utils';
-import cognitoIdentityPoolId from '../../../demo-credentials';
 
 let host;
 let scene;
@@ -16,6 +15,11 @@ async function createScene() {
   initUi();
 
   // ===== Configure the AWS SDK =====
+
+  // This is served by webpack-dev-server and comes from demo-credentials.js in the repo root
+  // If you copy this example, you will substitute in your own cognito Pool ID
+  const config = await (await fetch('/devConfig.json')).json();
+  const cognitoIdentityPoolId = config.cognitoIdentityPoolId;
 
   AWS.config.region = cognitoIdentityPoolId.split(':')[0];
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({

--- a/packages/demos-babylon/src/helloWorldDemo.js
+++ b/packages/demos-babylon/src/helloWorldDemo.js
@@ -1,7 +1,6 @@
 import {HostObject} from '@amazon-sumerian-hosts/babylon';
 import {Scene} from '@babylonjs/core/scene';
 import DemoUtils from './common/demo-utils';
-import cognitoIdentityPoolId from '../../../demo-credentials';
 
 let host;
 let scene;
@@ -15,6 +14,11 @@ async function createScene() {
   initUi();
 
   // ===== Configure the AWS SDK =====
+
+  // This is served by webpack-dev-server and comes from demo-credentials.js in the repo root
+  // If you copy this example, you will substitute in your own cognito Pool ID
+  const config = await (await fetch('/devConfig.json')).json();
+  const cognitoIdentityPoolId = config.cognitoIdentityPoolId;
 
   AWS.config.region = cognitoIdentityPoolId.split(':')[0];
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({


### PR DESCRIPTION
## Description

I found that `npm install` was failing on my Mac (it used to work.) I was able to fix the issue by upgrading the "eslint-config-airbnb" dependency from "^18.0.1" to "^19.0.4".

## Related Issue \#
n/a

## Reviewer Testing Instructions

1. Pull down this branch.
2. Remove untracked files by running `git clean -xfd`. (Essential resetting your local repo to a clean state.)
3. Run `npm install`.
4. Observe successful completion of the install.

## Submission Checklist

I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.