### PR TITLE
remove push from github action and update CodeQL version to v2 since …

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,6 @@ name: Run build/tests/lint on pull requests
 
 on:
   pull_request:
-  push:
 
 # By default the karma test runners use the karma 'Chrome' runner
 # This is great when running locally because the browser pops up and you get to see what it does
@@ -20,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
@@ -29,4 +28,4 @@ jobs:
       - run: npm run build-test
       - name: Perform CodeQL Analysis
         if: matrix.os == 'ubuntu-latest' # we only need to run this check on one platform
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Description
The dependbot failed to merge for a Github Action push so we removed push from the action. Meanwhile, the CodeQL v1 will deprecate this December so we updated it to v2 in this PR.

## Related Issue


## Reviewer Testing Instructions
For me, I restored the dependbot branch and create a pull request for that branch to my dev removePush branch and the Action works well without error.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.