### PR TITLE
Fix issue where HOSTS_VERSION was incompatible with packages not using webpack

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,10 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - name: "Set version number"
+        run: |
+          perl -i -p -e "s/HOSTS_VERSION = .*/HOSTS_VERSION = '${{ github.event.release.tag_name }}';/" ${{ github.workspace }}/packages/amazon-sumerian-hosts-core/src/core/Utils.js
+
       - run: npm run release
       - run: npm publish --workspaces --access public
         env:

--- a/packages/amazon-sumerian-hosts-core/src/core/Utils.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/Utils.js
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT-0
 import Deferred from './Deferred';
 
+// This line gets replaced by Github actions to the SHA of the git commit
+const HOSTS_VERSION = "development";
+
 /**
  * A collection of useful generic functions.
  *
@@ -194,9 +197,6 @@ class Utils {
   }
 
   static getVersion() {
-    // HOSTS_VERSION  is defined by Webpack, to the version of the library
-    // Either a git commit or a release version
-    // eslint-disable-next-line no-undef
     return HOSTS_VERSION;
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,10 +33,6 @@ if (process.env.ENGINE === 'core') {
 
 let devServerOnlyEntryPoints = {};
 
-// During a github build we pull the git commit sha out of the environment
-// for local builds we hardcode 'development', so we can differentiate these(i.e. in dev the commit hash is not really accurate)
-const HOSTS_VERSION = JSON.stringify(process.env.GITHUB_SHA || 'development');
-
 let prodOnlyExternals = [];
 
 if (isDevServer) {
@@ -133,7 +129,6 @@ module.exports = {
       banner: `Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\nSPDX-License-Identifier: MIT-0`,
       entryOnly: true,
     }),
-    new webpack.DefinePlugin({HOSTS_VERSION}),
   ],
   devServer: {
     devMiddleware: {


### PR DESCRIPTION


We were setting the HOSTS_VERSION at build time using webpack.

We also want customers who want to use modules/not use our webpack build to be able to do so.

These are incompatible.

To solve this, we are now writing out the version number into source at release time. This should have the same effect as before, anyone using an NPM release will get a version number, otherwise you will have 'development'.

I tested this in a release in my fork, you can see the overwritten file here in the artifacts: https://github.com/prestomation/amazon-sumerian-hosts/actions/runs/3301290701



## Related Issue #133 


## Reviewer Testing Instructions
Can't completely test without creating a release.
After this is merged we will perform a release and test our repro cases to fully test 


## Submission Checklist
I confirm that I have...
- [ x] removed hard-coded Cognito IDs
- [ x] manually smoke-tested the BabylonJS integration tests
- [ x] manually smoke-tested the BabylonJS demos
- [ x] manually smoke-tested the Three.js integration tests
- [ x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.