### PR TITLE
Fix semantic version comparison logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1627,6 +1627,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -8022,7 +8027,10 @@
     "packages/amazon-sumerian-hosts-core": {
       "name": "@amazon-sumerian-hosts/core",
       "version": "2.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "compare-versions": "^6.0.0-rc.1"
+      }
     },
     "packages/amazon-sumerian-hosts-three": {
       "name": "@amazon-sumerian-hosts/three",
@@ -8054,7 +8062,10 @@
       }
     },
     "@amazon-sumerian-hosts/core": {
-      "version": "file:packages/amazon-sumerian-hosts-core"
+      "version": "file:packages/amazon-sumerian-hosts-core",
+      "requires": {
+        "compare-versions": "*"
+      }
     },
     "@amazon-sumerian-hosts/three": {
       "version": "file:packages/amazon-sumerian-hosts-three",
@@ -9385,6 +9396,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
     },
     "compressible": {
       "version": "2.0.18",

--- a/packages/amazon-sumerian-hosts-core/package.json
+++ b/packages/amazon-sumerian-hosts-core/package.json
@@ -20,5 +20,8 @@
   "scripts": {
     "lint": "eslint .",
     "docs": "jsdoc -c jsdoc.conf.json"
+  },
+  "dependencies": {
+    "compare-versions": "^6.0.0-rc.1"
   }
 }

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
+import {compareVersions} from 'compare-versions';
 import AbstractHostFeature from '../AbstractHostFeature';
 import AnimationUtils from '../animpack/AnimationUtils';
 import MathUtils from '../MathUtils';
@@ -278,7 +279,7 @@ class AbstractTextToSpeechFeature extends AbstractHostFeature {
         response.Voices.forEach(voice => {
           if (
             voice.SupportedEngines.includes('standard') ||
-            version >= minNeuralSdk
+            compareVersions(version, minNeuralSdk) >= 0
           ) {
             availableVoices.push(voice);
           }


### PR DESCRIPTION
## Description
A condition statement was incorrectly performing a number comparison on two version strings. This resulted in some Polly neural voices being excluded from the available voice list.

There is still a bug that prevents some neural voices from being used with hosts. (An example is the "Elin" Swedish voice.) But this PR represents an important foundational fix that needs to be in place before that bug can be addressed.

## Related Issue \#
n/a

## Reviewer Testing Instructions
No new automated tests were implemented. The standard integration tests, and demos (BabylonJS and Three) should run and pass.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.