### PR TITLE
Fix support for neural-only voices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1627,6 +1627,11 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -8022,7 +8027,10 @@
     "packages/amazon-sumerian-hosts-core": {
       "name": "@amazon-sumerian-hosts/core",
       "version": "2.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "compare-versions": "^6.0.0-rc.1"
+      }
     },
     "packages/amazon-sumerian-hosts-three": {
       "name": "@amazon-sumerian-hosts/three",
@@ -8054,7 +8062,10 @@
       }
     },
     "@amazon-sumerian-hosts/core": {
-      "version": "file:packages/amazon-sumerian-hosts-core"
+      "version": "file:packages/amazon-sumerian-hosts-core",
+      "requires": {
+        "compare-versions": "*"
+      }
     },
     "@amazon-sumerian-hosts/three": {
       "version": "file:packages/amazon-sumerian-hosts-three",
@@ -9385,6 +9396,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
     },
     "compressible": {
       "version": "2.0.18",

--- a/packages/amazon-sumerian-hosts-core/package.json
+++ b/packages/amazon-sumerian-hosts-core/package.json
@@ -20,5 +20,8 @@
   "scripts": {
     "lint": "eslint .",
     "docs": "jsdoc -c jsdoc.conf.json"
+  },
+  "dependencies": {
+    "compare-versions": "^6.0.0-rc.1"
   }
 }

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
+import {compareVersions} from 'compare-versions';
 import AbstractHostFeature from '../AbstractHostFeature';
 import AnimationUtils from '../animpack/AnimationUtils';
 import MathUtils from '../MathUtils';
@@ -278,7 +279,7 @@ class AbstractTextToSpeechFeature extends AbstractHostFeature {
         response.Voices.forEach(voice => {
           if (
             voice.SupportedEngines.includes('standard') ||
-            version >= minNeuralSdk
+            compareVersions(version, minNeuralSdk) >= 0
           ) {
             availableVoices.push(voice);
           }

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
@@ -371,7 +371,10 @@ class AbstractTextToSpeechFeature extends AbstractHostFeature {
     // Default to the standard engine if neural is not available for this version
     if (
       engine === undefined ||
-      this.constructor.AWS_VERSION < this.constructor.POLLY_MIN_NEURAL_VERSION
+      compareVersions(
+        this.constructor.AWS_VERSION,
+        this.constructor.POLLY_MIN_NEURAL_VERSION
+      ) < 0
     ) {
       engine = this.constructor.POLLY_DEFAULTS.Engine;
     }


### PR DESCRIPTION
## Description
This is a bug fix. Prior to this PR, if a developer tried to configure a host to use a voice that was only supported with the Polly neural engine the voice ID would be ignored and the host would default to using the Amy (en-GB) voice.

The root cause was faulty conditional logic that didn't accurately identify when the neural engine was available. This PR fixes that.

## Related Issue \#
n/a

## Reviewer Testing Instructions
In the previous version of the repo, if you modified any of the demos to use a neural-only voice like "Elin" it would instead use "Amy" instead. Now if you modify any of the demos to use a neural-only voice, that voice will be used.

## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.