### PR TITLE
Publishing workflow is not triggering on the publishing of a release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [released]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
I believe that when a Release is created through the GitHub web portal, the `created` event will not be consistently fired. [According to the documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release), workflows will not be triggered on `create` when the release is saved as a draft. Changing the event to [released](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=released#release) should allow people to manage releases through the GitHub web portal without needing to care whether the release was ever saved as a draft or not.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.