### PR TITLE
Version update to 2.0.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,12 +128,18 @@ GitHub provides additional documentation on [forking a repository](https://help.
 
 The `@amazon-sumerian-hosts/core`, `@amazon-sumerian-hosts/babylon`, and `@amazon-sumerian-hosts/three` packages are all published and distributed via the [npmjs.com](https://www.npmjs.com/) registry. To publish a new version of the packages to the NPM registry, follow these steps...
 
-1. Update the package.json in the root of the repository, and then for each package with new version number using [semantic versioning](https://semver.org/). All packages should always share the same version number.
-2. Create a new release using the GitHub.com console. See [previous releases](https://github.com/aws-samples/amazon-sumerian-hosts/releases) for reference.
+1. Update `package.json` with a new version number using [semantic versioning](https://semver.org/). All of the packages in the repo should always share the same version number, so ensure that updates have been made to the `package.json` files in the following directories:
+	1. The root of the mono repository
+	1. `amazon-sumerian-hosts-babylon`
+	1. `amazon-sumerian-hosts-core`
+	1. `amazon-sumerian-hosts-three`
+	1. `demos-babylon`
+1. Make sure to run `npm install` to regenerate the `package-lock.json` file.
+1. Create a new release using the GitHub.com console. See [previous releases](https://github.com/aws-samples/amazon-sumerian-hosts/releases) for reference.
 	1. In the release creation form, create a new repository tag labeling it using the package version number prefixed with "v". *Example: "v2.1.3"*
 	2. Set the target of the release to the `mainline2.0` branch.
 	3. Set the title of the release to match the tag name. *Example: "v2.1.3"*
 	4. In the release description field, add a heading in the form **"Host Release *{version number}* - *{Reason for Release}*"**. Example: *"Host Release 1.3.1 - Bug Fixes"*
 	5. Append all significant changes as bullet points.
 1. Click "Publish release". This will automatically trigger a GitHub Action that publishes the release to the NPM registry.
-2. Validate the GitHub properly releases to NPM through Actions tab.
+1. Validate the GitHub properly releases to NPM through Actions tab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-sumerian-hosts",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-sumerian-hosts",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "workspaces": [
         "./packages/amazon-sumerian-hosts-core",
@@ -8013,7 +8013,7 @@
     },
     "packages/amazon-sumerian-hosts-babylon": {
       "name": "@amazon-sumerian-hosts/babylon",
-      "version": "2.0.4",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@amazon-sumerian-hosts/core": "^2.0.0",
@@ -8026,7 +8026,7 @@
     },
     "packages/amazon-sumerian-hosts-core": {
       "name": "@amazon-sumerian-hosts/core",
-      "version": "2.0.4",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "compare-versions": "^6.0.0-rc.1"
@@ -8034,7 +8034,7 @@
     },
     "packages/amazon-sumerian-hosts-three": {
       "name": "@amazon-sumerian-hosts/three",
-      "version": "2.0.4",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@amazon-sumerian-hosts/core": "^2.0.0"
@@ -8044,7 +8044,7 @@
       }
     },
     "packages/demos-babylon": {
-      "version": "2.0.0",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "@amazon-sumerian-hosts/babylon": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     "last 2 FirefoxAndroid versions",
     "last 2 iOS versions"
   ],
-  "version": "2.0.5"
+  "version": "2.0.6"
 }

--- a/packages/amazon-sumerian-hosts-babylon/package.json
+++ b/packages/amazon-sumerian-hosts-babylon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amazon-sumerian-hosts/babylon",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "license": "MIT",
   "author": {

--- a/packages/amazon-sumerian-hosts-core/package.json
+++ b/packages/amazon-sumerian-hosts-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amazon-sumerian-hosts/core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "license": "MIT",
   "author": {

--- a/packages/amazon-sumerian-hosts-core/src/core/Utils.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/Utils.js
@@ -3,7 +3,7 @@
 import Deferred from './Deferred';
 
 // This line gets replaced by Github actions to the SHA of the git commit
-const HOSTS_VERSION = "development";
+const HOSTS_VERSION = 'development';
 
 /**
  * A collection of useful generic functions.

--- a/packages/amazon-sumerian-hosts-three/package.json
+++ b/packages/amazon-sumerian-hosts-three/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amazon-sumerian-hosts/three",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "license": "MIT",
   "author": {

--- a/packages/demos-babylon/package.json
+++ b/packages/demos-babylon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demos-babylon",
-  "version": "2.0.0",
+  "version": "2.0.6",
   "description": "Demos of the Babylon version of the Amazon Sumerian Hosts JS library",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description
This PR updates all of the package versions to 2.0.6, and disambiguates the necessity of generating a new `package-lock.json` file.


## Submission Checklist
I confirm that I have...
- [x] removed hard-coded Cognito IDs
- [x] manually smoke-tested the BabylonJS integration tests
- [x] manually smoke-tested the BabylonJS demos
- [x] manually smoke-tested the Three.js integration tests
- [x] manually smoke-tested the Three.js demo


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.